### PR TITLE
Add Gmail SMTP email notifications (Issue #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ TWILIO_AUTH_TOKEN=your_auth_token
 TWILIO_WHATSAPP_FROM=whatsapp:+14155238886
 TWILIO_WHATSAPP_TO=whatsapp:+1234567890
 
+# Gmail SMTP Email (optional)
+# Generate App Password from https://myaccount.google.com/apppasswords
+GMAIL_SMTP_USER=yourname@gmail.com
+GMAIL_SMTP_PASSWORD=your_16_character_app_password
+GMAIL_SMTP_FROM=yourname@gmail.com  # Optional, defaults to GMAIL_SMTP_USER
+GMAIL_SMTP_TO=recipient@gmail.com  # Optional, for testing
+
 Usage
 Backend
 
@@ -318,15 +325,89 @@ If successful, you should receive a test message on WhatsApp. If you encounter e
 - Phone numbers are in the correct format with `whatsapp:` prefix
 - Your Twilio account has sufficient credits
 
+Gmail SMTP Email Configuration
+
+This project supports email notifications via Gmail SMTP with App Password authentication. Follow these steps to set it up:
+
+Step 1: Enable 2-Step Verification
+
+1. Go to your Google Account settings: https://myaccount.google.com/
+2. Navigate to "Security" section
+3. Under "Signing in to Google", enable "2-Step Verification" if not already enabled
+4. Follow the prompts to complete the setup (you'll need a phone number)
+
+Step 2: Generate Gmail App Password
+
+1. Go to your Google Account settings: https://myaccount.google.com/
+2. Navigate to "Security" section
+3. Under "Signing in to Google", find "2-Step Verification" and click on it
+4. Scroll down to find "App passwords" (you may need to search for it)
+5. Click on "App passwords"
+6. Select "Mail" as the app and "Other (Custom name)" as the device
+7. Enter a name like "PPRA Tender Alerts" and click "Generate"
+8. Google will display a 16-character password (e.g., `abcd efgh ijkl mnop`)
+9. **Copy this password immediately** - you won't be able to see it again
+10. Remove spaces from the password when adding it to your `.env` file
+
+**Important:** 
+- You cannot use your regular Gmail password for SMTP
+- App Passwords are required when 2-Step Verification is enabled
+- Each App Password is 16 characters (without spaces)
+
+Step 3: Configure Environment Variables
+
+1. Edit your `.env` file in the project root and add your Gmail SMTP credentials:
+   ```bash
+   GMAIL_SMTP_USER=yourname@gmail.com
+   GMAIL_SMTP_PASSWORD=abcdefghijklmnop  # Your 16-character App Password (no spaces)
+   GMAIL_SMTP_FROM=yourname@gmail.com  # Optional, defaults to GMAIL_SMTP_USER
+   GMAIL_SMTP_TO=recipient@gmail.com  # Optional, for testing purposes
+   ```
+
+   **Important:**
+   - Use your full Gmail address for `GMAIL_SMTP_USER`
+   - Use the 16-character App Password (without spaces) for `GMAIL_SMTP_PASSWORD`
+   - `GMAIL_SMTP_FROM` is optional and defaults to `GMAIL_SMTP_USER`
+   - `GMAIL_SMTP_TO` is optional and only needed for testing
+
+Step 4: Test Email Notifications
+
+Run the test script to verify the integration:
+
+```bash
+python tests/test_email_notification.py
+```
+
+Or if you need to use `python3`:
+
+```bash
+python3 tests/test_email_notification.py
+```
+
+The script will:
+- Check that all required environment variables are set
+- Initialize the email notifier
+- Send a test email to your configured email address
+- Display success/error messages
+
+If successful, you should receive a test email. If you encounter errors, check:
+- Your Gmail App Password is correct (16 characters, no spaces)
+- 2-Step Verification is enabled on your Google account
+- The recipient email address is correct
+- Check your spam/junk folder
+- Your internet connection is working
+- You're using an App Password, not your regular Gmail password
+
 Project Structure
 ppra-tender-alerts/
 ├─ scripts/           # Python scripts (fetch_tenders.py, etc.)
 ├─ data/              # JSON or DB storage
 ├─ tests/             # Test scripts
 │  ├─ test_whatsapp_notification.py  # WhatsApp notification test
+│  ├─ test_email_notification.py    # Email notification test
 ├─ backend/
 │  ├─ scraper/
-│  │  ├─ notifications.py    # WhatsApp notifications via Twilio
+│  │  ├─ notifications.py    # WhatsApp and Email notifications
 │  │  ├─ ppra_scraper.py
 │  │  └─ tender_storage.py
 │  ├─ ppra_tender_alerts/

--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Test Email Notification Script
+
+This script tests email sending via Gmail SMTP.
+It loads environment variables, initializes the email notifier,
+and sends a test email to verify the integration works correctly.
+"""
+
+import os
+import sys
+from dotenv import load_dotenv
+
+# Add parent directory to path to import scraper modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+from scraper.notifications import EmailNotifier
+
+
+def main():
+    """Main function to test email notification sending."""
+    # Load environment variables from .env file
+    load_dotenv()
+    
+    print("=" * 60)
+    print("Email Notification Test via Gmail SMTP")
+    print("=" * 60)
+    print()
+    
+    # Check if required environment variables are set
+    smtp_user = os.getenv('GMAIL_SMTP_USER')
+    smtp_password = os.getenv('GMAIL_SMTP_PASSWORD')
+    smtp_from = os.getenv('GMAIL_SMTP_FROM')
+    to_email = os.getenv('GMAIL_SMTP_TO')
+    
+    print("Checking environment variables...")
+    if not smtp_user:
+        print("❌ ERROR: GMAIL_SMTP_USER is not set in .env file")
+        print("   Please add your Gmail address to .env file")
+        print("   Example: GMAIL_SMTP_USER=yourname@gmail.com")
+        return 1
+    
+    if not smtp_password:
+        print("❌ ERROR: GMAIL_SMTP_PASSWORD is not set in .env file")
+        print("   Please add your Gmail App Password to .env file")
+        print("   See README.md for instructions on generating an App Password")
+        return 1
+    
+    if not to_email:
+        print("⚠️  WARNING: GMAIL_SMTP_TO is not set in .env file")
+        print("   Using GMAIL_SMTP_USER as recipient for testing")
+        to_email = smtp_user
+    else:
+        print(f"✅ Recipient email: {to_email}")
+    
+    print("✅ All required environment variables are set")
+    print()
+    
+    # Initialize email notifier
+    print("Initializing email notifier...")
+    try:
+        notifier = EmailNotifier()
+        print("✅ Email notifier initialized successfully")
+        print(f"   SMTP Server: {notifier.smtp_server}:{notifier.smtp_port}")
+        print(f"   From: {notifier.smtp_from}")
+        print()
+    except ValueError as e:
+        print(f"❌ ERROR: Failed to initialize email notifier")
+        print(f"   {str(e)}")
+        return 1
+    except Exception as e:
+        print(f"❌ ERROR: Unexpected error during initialization")
+        print(f"   {type(e).__name__}: {str(e)}")
+        return 1
+    
+    # Send test email
+    test_subject = "🧪 Test Email from PPRA Tender Alerts"
+    test_body = (
+        "This is a test email to verify Gmail SMTP email notifications.\n\n"
+        "If you received this email, the integration is working correctly! ✅\n\n"
+        "You can now use the EmailNotifier class to send tender alerts via email."
+    )
+    
+    print("Sending test email...")
+    print(f"To: {to_email}")
+    print(f"Subject: {test_subject}")
+    print()
+    
+    try:
+        result = notifier.send_email(to_email, test_subject, test_body)
+        
+        if result['success']:
+            print("✅ SUCCESS: Email sent successfully!")
+            print()
+            print("📧 Check your email inbox (and spam folder) to confirm receipt of the message.")
+            print()
+            print("Note: If you don't receive the email, check:")
+            print("  1. Your Gmail App Password is correct (16 characters)")
+            print("  2. 2-Step Verification is enabled on your Google account")
+            print("  3. The recipient email address is correct")
+            print("  4. Check your spam/junk folder")
+            print("  5. Your internet connection is working")
+            return 0
+        else:
+            print("❌ ERROR: Failed to send email")
+            print(f"   Error: {result['error']}")
+            print()
+            print("Troubleshooting tips:")
+            print("  - Verify your Gmail App Password is correct (not your regular password)")
+            print("  - Ensure 2-Step Verification is enabled on your Google account")
+            print("  - Check that 'Less secure app access' is not required (App Passwords replace this)")
+            print("  - Verify the recipient email address is valid")
+            print("  - Check your internet connection")
+            return 1
+            
+    except Exception as e:
+        print(f"❌ ERROR: Unexpected error while sending email")
+        print(f"   {type(e).__name__}: {str(e)}")
+        return 1
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.exit(exit_code)
+


### PR DESCRIPTION
- Add EmailNotifier class to notifications.py with Gmail SMTP support
- Support for plain text and HTML emails
- Add send_tender_alert method for formatted tender notifications
- Create test_email_notification.py test script
- Update README.md with Gmail SMTP configuration instructions
- Test email sent successfully

Closes #26